### PR TITLE
fix: restore browser lookups through Python fallbacks

### DIFF
--- a/docs/webworker.js
+++ b/docs/webworker.js
@@ -19,16 +19,15 @@ async function loadPyodideAndPackages() {
 let pyodideReadyPromise = loadPyodideAndPackages();
 
 self.onmessage = async (event) => {
-  // make sure loading is done
-  await pyodideReadyPromise;
-  // Don't bother yet with this line, suppose our API is built in such a way:
   const { id, python } = event.data;
-  // Now is the easy part, the one that is similar to working in the main thread:
   try {
+    // Initialization errors must be returned to the caller too; otherwise the
+    // page remains stuck on "Fetching..." forever.
+    await pyodideReadyPromise;
     await self.pyodide.loadPackagesFromImports(python);
     let results = await self.pyodide.runPythonAsync(python);
     self.postMessage({ results, id });
   } catch (error) {
-    self.postMessage({ error: error.message, id });
+    self.postMessage({ error: error.message || String(error), id });
   }
 };

--- a/docs/wenxian.js
+++ b/docs/wenxian.js
@@ -1,10 +1,11 @@
 import { asyncRun } from "./pyworker.js";
 
 async function from_identifier(identifier) {
+  const pythonIdentifier = JSON.stringify(identifier);
   const { results, error } = await asyncRun(`
-    import sys
     from wenxian.from_identifier import from_identifier
-    from_identifier("${identifier}").bibtex
+    reference = from_identifier(${pythonIdentifier})
+    reference.bibtex if reference is not None and not reference.is_empty() else None
     `);
   return { results, error };
 }
@@ -23,8 +24,12 @@ document.getElementById("submit").addEventListener("click", function (event) {
       // show the output
       output.style.display = "block";
       message.textContent = "";
+    } else if (!error) {
+      output.style.display = "none";
+      message.textContent = "No reference found.";
     }
     if (error) {
+      output.style.display = "none";
       message.textContent = error;
     }
   });

--- a/tests/test_browser_fallback.py
+++ b/tests/test_browser_fallback.py
@@ -2,15 +2,22 @@
 
 from __future__ import annotations
 
-from wenxian.from_identifier import from_arxiv, from_pmid
+import pytest
+
+from wenxian.from_identifier import _fetch_safely, from_arxiv, from_pmid, from_title
 from wenxian.reference import Reference
+
+
+def _raise(error: Exception):
+    """Raise an exception from a callable used by fallback tests."""
+    raise error
 
 
 def test_pmid_falls_back_after_network_error(monkeypatch):
     """Test a PubMed network failure does not abort PMID lookup."""
     monkeypatch.setattr(
         "wenxian.from_identifier.Pubmed.from_pmid",
-        lambda *args: (_ for _ in ()).throw(OSError("CORS")),
+        lambda *args: _raise(OSError("CORS")),
     )
     monkeypatch.setattr(
         "wenxian.from_identifier.Europepmc.from_pmid",
@@ -29,7 +36,7 @@ def test_arxiv_falls_back_after_network_error(monkeypatch):
     """Test an arXiv network failure does not abort arXiv lookup."""
     monkeypatch.setattr(
         "wenxian.from_identifier.Arxiv.from_arxiv",
-        lambda *args: (_ for _ in ()).throw(OSError("CORS")),
+        lambda *args: _raise(OSError("CORS")),
     )
     monkeypatch.setattr(
         "wenxian.from_identifier.Datacite.from_arxiv",
@@ -42,3 +49,59 @@ def test_arxiv_falls_back_after_network_error(monkeypatch):
     result = from_arxiv("2304.09409")
     assert result is not None
     assert result.title == "Fallback"
+
+
+def test_browser_catches_javascript_network_exception(monkeypatch):
+    """Test Pyodide-only exceptions are treated as feeder failures."""
+    monkeypatch.setattr("wenxian.from_identifier.sys.platform", "emscripten")
+
+    result = _fetch_safely(
+        "browser", lambda identifier: _raise(RuntimeError("JavaScript error")), "id"
+    )
+
+    assert result is None
+
+
+def test_native_python_does_not_hide_programming_errors(monkeypatch):
+    """Test unexpected native Python errors still propagate."""
+    monkeypatch.setattr("wenxian.from_identifier.sys.platform", "linux")
+
+    with pytest.raises(RuntimeError, match="programming error"):
+        _fetch_safely(
+            "native",
+            lambda identifier: _raise(RuntimeError("programming error")),
+            "id",
+        )
+
+
+def test_title_falls_back_to_semantic_scholar(monkeypatch):
+    """Test title lookup falls back when Crossref is unavailable."""
+    title = "Fallback title"
+    monkeypatch.setattr(
+        "wenxian.from_identifier.Crossref.from_title",
+        lambda *args: _raise(OSError("CORS")),
+    )
+    monkeypatch.setattr(
+        "wenxian.from_identifier.Semanticscholar.from_title",
+        lambda *args: "10.1234/example",
+    )
+    monkeypatch.setattr(
+        "wenxian.from_identifier.from_identifier",
+        lambda identifier: Reference(title=title, journal="Journal"),
+    )
+
+    result = from_title(title)
+    assert result is not None
+    assert result.title == title
+
+
+def test_title_returns_none_when_search_sources_fail(monkeypatch):
+    """Test title lookup returns None when all search sources fail."""
+    monkeypatch.setattr(
+        "wenxian.from_identifier.Crossref.from_title", lambda *args: None
+    )
+    monkeypatch.setattr(
+        "wenxian.from_identifier.Semanticscholar.from_title", lambda *args: None
+    )
+
+    assert from_title("Missing title") is None

--- a/tests/test_browser_fallback.py
+++ b/tests/test_browser_fallback.py
@@ -1,0 +1,44 @@
+"""Tests for browser-safe feeder fallbacks."""
+
+from __future__ import annotations
+
+from wenxian.from_identifier import from_arxiv, from_pmid
+from wenxian.reference import Reference
+
+
+def test_pmid_falls_back_after_network_error(monkeypatch):
+    """Test a PubMed network failure does not abort PMID lookup."""
+    monkeypatch.setattr(
+        "wenxian.from_identifier.Pubmed.from_pmid",
+        lambda *args: (_ for _ in ()).throw(OSError("CORS")),
+    )
+    monkeypatch.setattr(
+        "wenxian.from_identifier.Europepmc.from_pmid",
+        lambda *args: Reference(title="Fallback", journal="Journal"),
+    )
+    monkeypatch.setattr(
+        "wenxian.from_identifier.Semanticscholar.from_pmid", lambda *args: None
+    )
+
+    result = from_pmid("37526163")
+    assert result is not None
+    assert result.title == "Fallback"
+
+
+def test_arxiv_falls_back_after_network_error(monkeypatch):
+    """Test an arXiv network failure does not abort arXiv lookup."""
+    monkeypatch.setattr(
+        "wenxian.from_identifier.Arxiv.from_arxiv",
+        lambda *args: (_ for _ in ()).throw(OSError("CORS")),
+    )
+    monkeypatch.setattr(
+        "wenxian.from_identifier.Datacite.from_arxiv",
+        lambda *args: Reference(title="Fallback", journal="arXiv"),
+    )
+    monkeypatch.setattr(
+        "wenxian.from_identifier.Semanticscholar.from_arxiv", lambda *args: None
+    )
+
+    result = from_arxiv("2304.09409")
+    assert result is not None
+    assert result.title == "Fallback"

--- a/tests/test_datacite.py
+++ b/tests/test_datacite.py
@@ -15,9 +15,7 @@ class _Response:
             "data": {
                 "attributes": {
                     "doi": "10.48550/arXiv.2304.09409",
-                    "creators": [
-                        {"givenName": "Ada", "familyName": "Lovelace"}
-                    ],
+                    "creators": [{"givenName": "Ada", "familyName": "Lovelace"}],
                     "titles": [{"title": "A preprint"}],
                     "publisher": "arXiv",
                     "publicationYear": 2023,

--- a/tests/test_datacite.py
+++ b/tests/test_datacite.py
@@ -10,6 +10,7 @@ class _Response:
     status_code = 200
 
     def json(self):
+        """Return a minimal DataCite response."""
         return {
             "data": {
                 "attributes": {

--- a/tests/test_datacite.py
+++ b/tests/test_datacite.py
@@ -1,0 +1,47 @@
+"""Tests for the DataCite feeder."""
+
+from __future__ import annotations
+
+from wenxian.feeder.datacite import Datacite
+from wenxian.reference import Author, Reference
+
+
+class _Response:
+    status_code = 200
+
+    def json(self):
+        return {
+            "data": {
+                "attributes": {
+                    "doi": "10.48550/arXiv.2304.09409",
+                    "creators": [
+                        {"givenName": "Ada", "familyName": "Lovelace"}
+                    ],
+                    "titles": [{"title": "A preprint"}],
+                    "publisher": "arXiv",
+                    "publicationYear": 2023,
+                    "types": {"bibtex": "article"},
+                    "descriptions": [
+                        {"descriptionType": "Abstract", "description": "Abstract"}
+                    ],
+                    "container": {},
+                }
+            }
+        }
+
+
+def test_from_arxiv(monkeypatch):
+    """Test converting an arXiv DataCite record to a reference."""
+    monkeypatch.setattr(
+        "wenxian.feeder.datacite.SESSION.get", lambda *args, **kwargs: _Response()
+    )
+
+    assert Datacite().from_arxiv("2304.09409") == Reference(
+        author=[Author(first="Ada", last="Lovelace")],
+        title="A preprint",
+        journal="arXiv",
+        year=2023,
+        pages="2304.09409",
+        annote="Abstract",
+        doi="10.48550/arXiv.2304.09409",
+    )

--- a/tests/test_datacite.py
+++ b/tests/test_datacite.py
@@ -106,3 +106,17 @@ def test_from_attributes_handles_name_and_type_fallbacks():
         pages=(10, 12),
         doi="10.1234/example",
     )
+
+
+def test_from_attributes_handles_single_first_page():
+    """Test DataCite metadata with only a first page."""
+    data = {
+        "doi": "10.1234/page",
+        "titles": [{"title": "Single page metadata"}],
+        "publisher": "Example Publisher",
+        "publicationYear": 2024,
+        "container": {"firstPage": "7"},
+    }
+
+    reference = Datacite()._from_attributes(data, doi="10.1234/page")
+    assert reference.pages == (7,)

--- a/tests/test_datacite.py
+++ b/tests/test_datacite.py
@@ -58,6 +58,15 @@ def test_from_arxiv(monkeypatch):
     )
 
 
+def test_from_arxiv_ignores_missing_doi(monkeypatch):
+    """Test an arXiv identifier missing from DataCite is ignored."""
+    monkeypatch.setattr(
+        "wenxian.feeder.datacite.SESSION.get",
+        lambda *args, **kwargs: _NotFoundResponse(),
+    )
+    assert Datacite().from_arxiv("0000.00000") is None
+
+
 def test_from_doi_ignores_missing_records(monkeypatch):
     """Test missing and empty DataCite records are ignored."""
     monkeypatch.setattr(

--- a/tests/test_datacite.py
+++ b/tests/test_datacite.py
@@ -29,6 +29,18 @@ class _Response:
         }
 
 
+class _NotFoundResponse:
+    status_code = 404
+
+
+class _EmptyResponse:
+    status_code = 200
+
+    def json(self):
+        """Return a DataCite response without DOI attributes."""
+        return {"data": {}}
+
+
 def test_from_arxiv(monkeypatch):
     """Test converting an arXiv DataCite record to a reference."""
     monkeypatch.setattr(
@@ -43,4 +55,54 @@ def test_from_arxiv(monkeypatch):
         pages="2304.09409",
         annote="Abstract",
         doi="10.48550/arXiv.2304.09409",
+    )
+
+
+def test_from_doi_ignores_missing_records(monkeypatch):
+    """Test missing and empty DataCite records are ignored."""
+    monkeypatch.setattr(
+        "wenxian.feeder.datacite.SESSION.get",
+        lambda *args, **kwargs: _NotFoundResponse(),
+    )
+    assert Datacite().from_doi("10.1234/missing") is None
+
+    monkeypatch.setattr(
+        "wenxian.feeder.datacite.SESSION.get", lambda *args, **kwargs: _EmptyResponse()
+    )
+    assert Datacite().from_doi("10.1234/empty") is None
+
+
+def test_from_attributes_handles_name_and_type_fallbacks():
+    """Test fallback creator names, pages, and unknown BibTeX types."""
+    data = {
+        "doi": "10.1234/example",
+        "creators": [
+            {"name": "Lovelace, Ada"},
+            {"name": "Grace Hopper"},
+        ],
+        "titles": [{"title": "Fallback metadata"}],
+        "publisher": "Example Publisher",
+        "publicationYear": "2024",
+        "types": {"bibtex": "unknown"},
+        "descriptions": [{"descriptionType": "Other", "description": "Ignored"}],
+        "container": {
+            "volume": "2",
+            "issue": "1",
+            "firstPage": "10",
+            "lastPage": "12",
+        },
+    }
+
+    assert Datacite()._from_attributes(data, doi="10.1234/example") == Reference(
+        author=[
+            Author(first="Ada", last="Lovelace"),
+            Author(first="Grace", last="Hopper"),
+        ],
+        title="Fallback metadata",
+        journal="Example Publisher",
+        year=2024,
+        volume=2,
+        issue=1,
+        pages=(10, 12),
+        doi="10.1234/example",
     )

--- a/tests/test_europepmc.py
+++ b/tests/test_europepmc.py
@@ -21,9 +21,7 @@ class _Response:
                         "doi": "10.1234/example",
                         "abstractText": "Abstract",
                         "authorList": {
-                            "author": [
-                                {"firstName": "Ada", "lastName": "Lovelace"}
-                            ]
+                            "author": [{"firstName": "Ada", "lastName": "Lovelace"}]
                         },
                         "journalInfo": {
                             "volume": "4",

--- a/tests/test_europepmc.py
+++ b/tests/test_europepmc.py
@@ -1,0 +1,54 @@
+"""Tests for the Europe PMC feeder."""
+
+from __future__ import annotations
+
+from wenxian.feeder.europepmc import Europepmc
+from wenxian.reference import Author, Reference
+
+
+class _Response:
+    status_code = 200
+
+    def json(self):
+        return {
+            "resultList": {
+                "result": [
+                    {
+                        "title": "A paper",
+                        "pubYear": "2026",
+                        "pageInfo": "12-18",
+                        "doi": "10.1234/example",
+                        "abstractText": "Abstract",
+                        "authorList": {
+                            "author": [
+                                {"firstName": "Ada", "lastName": "Lovelace"}
+                            ]
+                        },
+                        "journalInfo": {
+                            "volume": "4",
+                            "issue": "2",
+                            "journal": {"title": "Journal of Tests"},
+                        },
+                    }
+                ]
+            }
+        }
+
+
+def test_from_pmid(monkeypatch):
+    """Test converting a Europe PMC result to a reference."""
+    monkeypatch.setattr(
+        "wenxian.feeder.europepmc.SESSION.get", lambda *args, **kwargs: _Response()
+    )
+
+    assert Europepmc().from_pmid("37526163") == Reference(
+        author=[Author(first="Ada", last="Lovelace")],
+        title="A paper",
+        journal="Journal of Tests",
+        year=2026,
+        volume=4,
+        issue=2,
+        pages=(12, 18),
+        annote="Abstract",
+        doi="10.1234/example",
+    )

--- a/tests/test_europepmc.py
+++ b/tests/test_europepmc.py
@@ -10,6 +10,7 @@ class _Response:
     status_code = 200
 
     def json(self):
+        """Return a minimal Europe PMC response."""
         return {
             "resultList": {
                 "result": [

--- a/tests/test_europepmc.py
+++ b/tests/test_europepmc.py
@@ -34,6 +34,18 @@ class _Response:
         }
 
 
+class _NotFoundResponse:
+    status_code = 503
+
+
+class _EmptyResponse:
+    status_code = 200
+
+    def json(self):
+        """Return a Europe PMC response without results."""
+        return {"resultList": {"result": []}}
+
+
 def test_from_pmid(monkeypatch):
     """Test converting a Europe PMC result to a reference."""
     monkeypatch.setattr(
@@ -50,4 +62,36 @@ def test_from_pmid(monkeypatch):
         pages=(12, 18),
         annote="Abstract",
         doi="10.1234/example",
+    )
+
+
+def test_from_pmid_ignores_missing_records(monkeypatch):
+    """Test failed and empty Europe PMC responses are ignored."""
+    monkeypatch.setattr(
+        "wenxian.feeder.europepmc.SESSION.get",
+        lambda *args, **kwargs: _NotFoundResponse(),
+    )
+    assert Europepmc().from_pmid("37526163") is None
+
+    monkeypatch.setattr(
+        "wenxian.feeder.europepmc.SESSION.get", lambda *args, **kwargs: _EmptyResponse()
+    )
+    assert Europepmc().from_pmid("37526163") is None
+
+
+def test_from_result_uses_full_name_and_journal_fallbacks():
+    """Test fallback fields in a Europe PMC result."""
+    result = {
+        "title": "Fallback metadata",
+        "pubYear": "2025",
+        "authorList": {"author": [{"fullName": "Grace Hopper"}]},
+        "journalTitle": "Journal of Fallbacks",
+        "journalInfo": {},
+    }
+
+    assert Europepmc()._from_result(result) == Reference(
+        author=[Author(first="Grace", last="Hopper")],
+        title="Fallback metadata",
+        journal="Journal of Fallbacks",
+        year=2025,
     )

--- a/wenxian/feeder/datacite.py
+++ b/wenxian/feeder/datacite.py
@@ -1,0 +1,94 @@
+"""Feeder for the DataCite REST API."""
+
+from __future__ import annotations
+
+from wenxian.feeder.feeder import Feeder
+from wenxian.feeder.session import SESSION
+from wenxian.reference import Author, BibtexType, Reference
+
+
+class Datacite(Feeder):
+    """Feeder for the DataCite REST API."""
+
+    API_URL = "https://api.datacite.org/dois"
+    ARXIV_DOI_PREFIX = "10.48550/arXiv."
+
+    def from_doi(self, doi: str) -> Reference | None:
+        """Fetch a reference from a DOI."""
+        r = SESSION.get(f"{self.API_URL}/{doi}")
+        if r.status_code != 200:
+            return None
+
+        data = r.json().get("data", {}).get("attributes", {})
+        if not data:
+            return None
+        return self._from_attributes(data, doi=doi)
+
+    def from_arxiv(self, arxiv: str) -> Reference | None:
+        """Fetch a reference from an arXiv identifier."""
+        doi = f"{self.ARXIV_DOI_PREFIX}{arxiv}"
+        reference = self.from_doi(doi)
+        if reference is None:
+            return None
+        reference.journal = "arXiv"
+        reference.pages = arxiv
+        return reference
+
+    def _from_attributes(self, data: dict, doi: str) -> Reference:
+        """Convert DataCite attributes into a reference."""
+        authors = []
+        for item in data.get("creators", []):
+            first = item.get("givenName")
+            last = item.get("familyName")
+            if last is None and item.get("name"):
+                name = item["name"]
+                if "," in name:
+                    last, first = (part.strip() for part in name.split(",", 1))
+                else:
+                    parts = name.split()
+                    first = " ".join(parts[:-1])
+                    last = parts[-1]
+            if first is not None and last is not None:
+                authors.append(Author(first=first, last=last))
+
+        titles = data.get("titles") or []
+        title = titles[0].get("title") if titles else None
+        container = data.get("container") or {}
+        journal = container.get("title") or data.get("publisher")
+
+        descriptions = data.get("descriptions") or []
+        abstract = next(
+            (
+                item.get("description")
+                for item in descriptions
+                if item.get("descriptionType") == "Abstract"
+            ),
+            None,
+        )
+
+        type_name = (data.get("types") or {}).get("bibtex", "article")
+        try:
+            bibtex_type = BibtexType[type_name]
+        except KeyError:
+            bibtex_type = BibtexType.article
+
+        pages = None
+        first_page = container.get("firstPage")
+        last_page = container.get("lastPage")
+        if first_page and last_page:
+            pages = self._pages(f"{first_page}-{last_page}")
+        elif first_page:
+            pages = self._pages(str(first_page))
+
+        return Reference(
+            author=authors or None,
+            title=title,
+            journal=journal,
+            year=self._int(data.get("publicationYear")),
+            volume=self._int(container.get("volume")),
+            issue=self._int(container.get("issue")),
+            pages=pages,
+            annote=abstract,
+            doi=data.get("doi") or doi,
+            type=bibtex_type,
+        )

--- a/wenxian/feeder/europepmc.py
+++ b/wenxian/feeder/europepmc.py
@@ -1,0 +1,61 @@
+"""Feeder for the Europe PMC API."""
+
+from __future__ import annotations
+
+from wenxian.feeder.feeder import Feeder
+from wenxian.feeder.session import SESSION
+from wenxian.reference import Author, Reference
+
+
+class Europepmc(Feeder):
+    """Feeder for the Europe PMC API."""
+
+    API_URL = "https://www.ebi.ac.uk/europepmc/webservices/rest/search"
+
+    def from_pmid(self, pmid: str | int) -> Reference | None:
+        """Fetch a reference from a PubMed identifier."""
+        r = SESSION.get(
+            self.API_URL,
+            params={
+                "query": f"EXT_ID:{pmid} AND SRC:MED",
+                "resultType": "core",
+                "format": "json",
+                "pageSize": "1",
+            },
+        )
+        if r.status_code != 200:
+            return None
+
+        results = r.json().get("resultList", {}).get("result", [])
+        if not results:
+            return None
+        return self._from_result(results[0])
+
+    def _from_result(self, result: dict) -> Reference:
+        """Convert a Europe PMC result into a reference."""
+        authors = []
+        for item in result.get("authorList", {}).get("author", []):
+            first = item.get("firstName")
+            last = item.get("lastName")
+            if last is None and item.get("fullName"):
+                parts = item["fullName"].split()
+                first = " ".join(parts[:-1])
+                last = parts[-1]
+            if first is not None and last is not None:
+                authors.append(Author(first=first, last=last))
+
+        journal_info = result.get("journalInfo") or {}
+        journal_data = journal_info.get("journal") or {}
+        journal = journal_data.get("title") or result.get("journalTitle")
+
+        return Reference(
+            author=authors or None,
+            title=result.get("title"),
+            journal=journal,
+            year=self._int(result.get("pubYear")),
+            volume=self._int(journal_info.get("volume")),
+            issue=self._int(journal_info.get("issue")),
+            pages=self._pages(result.get("pageInfo")),
+            annote=result.get("abstractText"),
+            doi=result.get("doi"),
+        )

--- a/wenxian/from_identifier.py
+++ b/wenxian/from_identifier.py
@@ -3,9 +3,8 @@
 from __future__ import annotations
 
 import sys
-from collections.abc import Callable
 from difflib import SequenceMatcher
-from typing import Any, TypeVar
+from typing import TYPE_CHECKING, TypeVar
 
 from requests.exceptions import RequestException
 
@@ -20,6 +19,9 @@ from wenxian.identifier import Identifier, get_identifier_type
 from wenxian.logger import logger
 from wenxian.reference import Reference
 
+if TYPE_CHECKING:
+    from collections.abc import Callable
+
 T = TypeVar("T")
 
 
@@ -31,7 +33,7 @@ def _title_similarity(title1: str, title2: str) -> float:
 
 
 def _fetch_safely(
-    source: str, fetcher: Callable[[Any], T | None], identifier: Any
+    source: str, fetcher: Callable[..., T | None], identifier: object
 ) -> T | None:
     """Fetch from one source without aborting a browser fallback chain."""
     try:

--- a/wenxian/from_identifier.py
+++ b/wenxian/from_identifier.py
@@ -2,49 +2,86 @@
 
 from __future__ import annotations
 
+import sys
 from difflib import SequenceMatcher
+from typing import Any, Callable, TypeVar
+
+from requests.exceptions import RequestException
 
 from wenxian.feeder.arxiv import Arxiv
 from wenxian.feeder.chemrxiv import Chemrxiv
 from wenxian.feeder.crossref import Crossref
+from wenxian.feeder.datacite import Datacite
+from wenxian.feeder.europepmc import Europepmc
 from wenxian.feeder.pubmed import Pubmed
 from wenxian.feeder.semanticscholar import Semanticscholar
 from wenxian.identifier import Identifier, get_identifier_type
 from wenxian.logger import logger
 from wenxian.reference import Reference
 
+T = TypeVar("T")
+
 
 def _title_similarity(title1: str, title2: str) -> float:
     """Calculate similarity between two titles (0.0 to 1.0)."""
-    # Normalize titles: lowercase and strip whitespace
     t1 = title1.lower().strip()
     t2 = title2.lower().strip()
     return SequenceMatcher(None, t1, t2).ratio()
 
 
+def _fetch_safely(
+    source: str, fetcher: Callable[[Any], T | None], identifier: Any
+) -> T | None:
+    """Fetch from one source without aborting a browser fallback chain."""
+    try:
+        return fetcher(identifier)
+    except (OSError, RequestException) as exc:
+        logger.warning("%s lookup failed for %s: %s", source, identifier, exc)
+        return None
+    except Exception as exc:
+        # Browser networking can surface JavaScript exceptions that are not
+        # requests exceptions. Keep native Python strict so programming errors
+        # remain visible during normal use and tests.
+        if sys.platform != "emscripten":
+            raise
+        logger.warning("%s browser lookup failed for %s: %s", source, identifier, exc)
+        return None
+
+
 def from_doi(doi: str) -> Reference | None:
     """Fetch a reference from a DOI."""
-    # pubmed is the most reliable source
     return (
         Reference()
-        | Pubmed().from_doi(doi)
-        | Crossref().from_doi(doi)
-        | Arxiv().from_doi(doi)
-        | Chemrxiv().from_doi(doi)
-        | Semanticscholar().from_doi(doi)
+        | _fetch_safely("PubMed", Pubmed().from_doi, doi)
+        | _fetch_safely("Crossref", Crossref().from_doi, doi)
+        | _fetch_safely("arXiv", Arxiv().from_doi, doi)
+        | _fetch_safely("ChemRxiv", Chemrxiv().from_doi, doi)
+        | _fetch_safely("Semantic Scholar", Semanticscholar().from_doi, doi)
     )
 
 
 def from_pmid(pmid: str | int) -> Reference | None:
     """Fetch a reference from a PMID."""
-    # no need to fetch from crossref - pubmed usually has all information
-    return Reference() | Pubmed().from_pmid(pmid)
+    reference = _fetch_safely("PubMed", Pubmed().from_pmid, pmid)
+    if reference is not None and not reference.is_empty():
+        return reference
+    return (
+        Reference()
+        | _fetch_safely("Europe PMC", Europepmc().from_pmid, pmid)
+        | _fetch_safely("Semantic Scholar", Semanticscholar().from_pmid, pmid)
+    )
 
 
 def from_arxiv(arxiv: str) -> Reference | None:
     """Fetch a reference from an arXiv identifier."""
-    # arxiv api has all information for arxiv papers
-    return Reference() | Arxiv().from_arxiv(arxiv)
+    reference = _fetch_safely("arXiv", Arxiv().from_arxiv, arxiv)
+    if reference is not None and not reference.is_empty():
+        return reference
+    return (
+        Reference()
+        | _fetch_safely("DataCite", Datacite().from_arxiv, arxiv)
+        | _fetch_safely("Semantic Scholar", Semanticscholar().from_arxiv, arxiv)
+    )
 
 
 def from_title(title: str) -> Reference | None:
@@ -55,25 +92,23 @@ def from_title(title: str) -> Reference | None:
     metadata from multiple sources for the best quality data.
     Validates that the returned title is similar to the input title.
     """
-    # Try to find an identifier from search APIs
-    # Use 'or' for lazy evaluation - try Crossref first, then Semantic Scholar
-    identifier_info = Crossref().from_title(title) or Semanticscholar().from_title(
-        title
-    )
+    identifier_info = _fetch_safely("Crossref", Crossref().from_title, title)
+    if identifier_info is None:
+        identifier_info = _fetch_safely(
+            "Semantic Scholar", Semanticscholar().from_title, title
+        )
     if identifier_info is None:
         return None
+    assert isinstance(identifier_info, str)
 
-    # Fetch metadata using the full feeder chain based on identifier type
     result = from_identifier(identifier_info)
 
-    # Validate that the returned title is similar to the input
     if result and result.title:
         similarity = _title_similarity(title, result.title)
-        if similarity < 0.6:  # Threshold for acceptable similarity
+        if similarity < 0.6:
             logger.warning(
                 f"Title mismatch: input='{title}' vs output='{result.title}' (similarity: {similarity:.2f})"
             )
-            # Return an empty Reference to signal low-confidence/incorrect match
             return None
 
     return result

--- a/wenxian/from_identifier.py
+++ b/wenxian/from_identifier.py
@@ -3,8 +3,9 @@
 from __future__ import annotations
 
 import sys
+from collections.abc import Callable
 from difflib import SequenceMatcher
-from typing import Any, Callable, TypeVar
+from typing import Any, TypeVar
 
 from requests.exceptions import RequestException
 


### PR DESCRIPTION
## Summary

- keep the browser as a thin Pyodide wrapper around the `wenxian` Python package
- tolerate feeder network/CORS failures in Pyodide without masking native Python programming errors
- add Europe PMC fallback for PMID and DataCite fallback for arXiv
- surface Pyodide initialization failures instead of leaving the page on `Fetching...`
- pass identifiers/titles safely from JavaScript into Python
- add regression tests for the new Python fallbacks

## Why

The browser version runs the same Python package, so its network requests are still subject to browser CORS restrictions. A failure in a primary feeder can currently abort the lookup before another source is tried. This change keeps citation parsing, metadata normalization, and BibTeX generation in Python while making the feeder chain resilient in the browser.

## Validation

- pre-commit.ci: passed
- Python 3.10 full pytest/coverage job: passed
- Python 3.13 full pytest/coverage job: passed
- GitHub Action tests: passed
- package build: passed
- Codecov patch coverage: 100.00%
- Codecov project coverage: 87.85% (base 84.89%, +2.96%)
- Codecov confirms all modified and coverable lines are covered by tests
- checked JavaScript with `node --check` and verified quoted/Unicode identifiers are represented as valid Python string literals

## Release note

The web worker installs `wenxian` from PyPI. After merge, a new tagged package release is required before the live website consumes the new Python feeder fallback code.

Agent: ChatGPT
Model: GPT-5.6 Sol